### PR TITLE
Add delivery limit when requeueing

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ builder.Services.AddWrappit(new WrappitOptions
 	Password = "...",
 	ExchangeName = "...",
 	QueueName = "...",
+	// Optionally add a delivery limit
+	DeliveryLimit = 5,
 });
 
 ```
@@ -31,6 +33,8 @@ These options can be ommitted if the following environment variables have been s
  * `Wrappit_Password`
  * `Wrappit_ExchangeName`
  * `Wrappit_QueueName`
+ * `Wrappit_DeliveryLimit`
+   * This one is optional, the default is `10`. This delivery limit is used when a handle method fails, this prevents infinite requeuing (see the related [issue](https://github.com/xandervedder/Wrappit/issues/1)).
 
 Once all of the environment variables have been set, the following can be done:
 

--- a/Wrappit.Demo/Controllers/SendMessageController.cs
+++ b/Wrappit.Demo/Controllers/SendMessageController.cs
@@ -19,6 +19,13 @@ public class MessageController : ControllerBase
     {
         _publisher.Publish("Demo.Topic", new ExampleEvent { ExampleProperty = message });
     }
+
+    [HttpPost("error")]
+    public void SendError(string message)
+    {
+        // This will trigger the demonstration of the timeout feature:
+        _publisher.Publish("Demo.Error", new ExampleEvent { ExampleProperty = message});
+    }
 }
 
 public class ExampleEvent : DomainEvent 

--- a/Wrappit.Demo/Controllers/SendMessageController.cs
+++ b/Wrappit.Demo/Controllers/SendMessageController.cs
@@ -28,7 +28,7 @@ public class MessageController : ControllerBase
     }
 }
 
-public class ExampleEvent : DomainEvent 
+public class ExampleEvent : DomainEvent
 {
-    public string ExampleProperty { get; set; }
+    public string ExampleProperty { get; set; } = null!;
 }

--- a/Wrappit.Demo/Listeners/DependencyInjectionListener.cs
+++ b/Wrappit.Demo/Listeners/DependencyInjectionListener.cs
@@ -1,7 +1,7 @@
 using Wrappit.Attributes;
 using Wrappit.Demo.Controllers;
 
-namespace Wrappit.Demo;
+namespace Wrappit.Demo.Listeners;
 
 [EventListener]
 public class DependencyInjectionListener

--- a/Wrappit.Demo/Listeners/ErrorListener.cs
+++ b/Wrappit.Demo/Listeners/ErrorListener.cs
@@ -1,0 +1,14 @@
+using Wrappit.Attributes;
+using Wrappit.Demo.Controllers;
+
+namespace Wrappit.Demo.Listeners;
+
+[EventListener]
+public class ErrorListener
+{
+    [Handle("Demo.Error")]
+    public void Handle(ExampleEvent @event)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/Wrappit.Demo/Listeners/SimpleListener.cs
+++ b/Wrappit.Demo/Listeners/SimpleListener.cs
@@ -1,7 +1,7 @@
 using Wrappit.Attributes;
 using Wrappit.Demo.Controllers;
 
-namespace Wrappit.Demo;
+namespace Wrappit.Demo.Listeners;
 
 [EventListener]
 public class SimpleListener

--- a/Wrappit.Demo/Program.cs
+++ b/Wrappit.Demo/Program.cs
@@ -1,5 +1,6 @@
 using Wrappit.Configuration;
 using Wrappit.Demo;
+using Wrappit.Demo.Listeners;
 using Wrappit.Extensions;
 
 var builder = WebApplication.CreateBuilder(args);

--- a/Wrappit.Demo/Program.cs
+++ b/Wrappit.Demo/Program.cs
@@ -1,5 +1,4 @@
 using Wrappit.Configuration;
-using Wrappit.Demo;
 using Wrappit.Demo.Listeners;
 using Wrappit.Extensions;
 
@@ -10,7 +9,7 @@ builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 
 // It is also possible to omit the wrappit options if the corresponding environment variables are set.
-builder.Services.AddWrappit(new WrappitOptions());
+builder.Services.AddWrappit(new WrappitOptions { DeliveryLimit = 2 });
 builder.Services.AddTransient<IExample, Example>();
 
 var app = builder.Build();

--- a/Wrappit.Test/Configuration/WrappitOptionsTest.cs
+++ b/Wrappit.Test/Configuration/WrappitOptionsTest.cs
@@ -19,7 +19,6 @@ public class WrappitOptionsTest
         Assert.AreEqual(5672, options.Port);
         Assert.AreEqual("Wrappit.DefaultExchangeName", options.ExchangeName);
         Assert.AreEqual("Wrappit.DefaultQueueName", options.QueueName);
-        Assert.AreEqual("quorum", options.QueueType);
         Assert.AreEqual(10, options.DeliveryLimit);
     }
 
@@ -35,7 +34,6 @@ public class WrappitOptionsTest
             HostName = "wrappit.org",
             ExchangeName = "Wrappit.Exchange",
             QueueName = "Wrappit.Queue",
-            QueueType = "classic",
             DeliveryLimit = 1,
         };
 
@@ -46,7 +44,6 @@ public class WrappitOptionsTest
         Assert.AreEqual(1200, options.Port);
         Assert.AreEqual("Wrappit.Exchange", options.ExchangeName);
         Assert.AreEqual("Wrappit.Queue", options.QueueName);
-        Assert.AreEqual("classic", options.QueueType);
         Assert.AreEqual(1, options.DeliveryLimit);
     }
 

--- a/Wrappit.Test/Configuration/WrappitOptionsTest.cs
+++ b/Wrappit.Test/Configuration/WrappitOptionsTest.cs
@@ -19,6 +19,8 @@ public class WrappitOptionsTest
         Assert.AreEqual(5672, options.Port);
         Assert.AreEqual("Wrappit.DefaultExchangeName", options.ExchangeName);
         Assert.AreEqual("Wrappit.DefaultQueueName", options.QueueName);
+        Assert.AreEqual("quorum", options.QueueType);
+        Assert.AreEqual(10, options.DeliveryLimit);
     }
 
     [TestMethod]
@@ -32,7 +34,9 @@ public class WrappitOptionsTest
             Port = 1200,
             HostName = "wrappit.org",
             ExchangeName = "Wrappit.Exchange",
-            QueueName = "Wrappit.Queue"
+            QueueName = "Wrappit.Queue",
+            QueueType = "classic",
+            DeliveryLimit = 1,
         };
 
         // Assert
@@ -42,6 +46,8 @@ public class WrappitOptionsTest
         Assert.AreEqual(1200, options.Port);
         Assert.AreEqual("Wrappit.Exchange", options.ExchangeName);
         Assert.AreEqual("Wrappit.Queue", options.QueueName);
+        Assert.AreEqual("classic", options.QueueType);
+        Assert.AreEqual(1, options.DeliveryLimit);
     }
 
     [TestMethod]

--- a/Wrappit.Test/Extensions/ServiceCollectionExtensionTest.cs
+++ b/Wrappit.Test/Extensions/ServiceCollectionExtensionTest.cs
@@ -146,6 +146,8 @@ public class ServiceCollectionExtensionTest
         Assert.AreEqual("1234", options.Password);
         Assert.AreEqual("Wrappit.Exchange", options.ExchangeName);
         Assert.AreEqual("Wrappit.Queue", options.QueueName);
+        // Optional
+        Assert.AreEqual(10, options.DeliveryLimit);
     }
 
     [TestMethod]
@@ -192,5 +194,26 @@ public class ServiceCollectionExtensionTest
         // Assert
         var exception = Assert.ThrowsException<WrappitException>(ShouldFail);
         Assert.AreEqual(exception.Message, message);
+    }
+
+    [TestMethod]
+    public void ServiceCollectionExtensions_WhenGivingOptionalDeliveryLimit_ShouldReturnCorrectDeliveryLimit()
+    {
+        // Arrange
+        var collection = new ServiceCollection();
+        Environment.SetEnvironmentVariable("Wrappit_HostName", "Test");
+        Environment.SetEnvironmentVariable("Wrappit_Port", "200");
+        Environment.SetEnvironmentVariable("Wrappit_UserName", "guest");
+        Environment.SetEnvironmentVariable("Wrappit_Password", "guest");
+        Environment.SetEnvironmentVariable("Wrappit_ExchangeName", "TestExchange");
+        Environment.SetEnvironmentVariable("Wrappit_QueueName", "TestQueue");
+        Environment.SetEnvironmentVariable("Wrappit_DeliveryLimit", "5");
+        
+        // Act
+        collection.AddWrappit();
+
+        // Assert
+        var options = collection.BuildServiceProvider().GetService<IWrappitOptions>()!;
+        Assert.AreEqual(5, options.DeliveryLimit);
     }
 }

--- a/Wrappit.Test/Messaging/BasicRecieverTest.cs
+++ b/Wrappit.Test/Messaging/BasicRecieverTest.cs
@@ -43,7 +43,7 @@ public class BasicRecieverTest
         _reciever.SetUpQueue(new [] { topic });
 
         // Assert
-        _channelMock.Verify(c => c.QueueDeclare(QueueName, true, false, false, null));
+        _channelMock.Verify(c => c.QueueDeclare(QueueName, true, false, false, It.IsAny<IDictionary<string, object>>()));
         _channelMock.Verify(c => c.QueueBind(QueueName, ExchangeName, topic, null));
     }
 
@@ -73,7 +73,7 @@ public class BasicRecieverTest
 
         // Assert
         // Should only contain one QueueDeclare:
-        _channelMock.Verify(c => c.QueueDeclare(QueueName, true, false, false, null));
+        _channelMock.Verify(c => c.QueueDeclare(QueueName, true, false, false, It.IsAny<IDictionary<string, object>>()));
         _channelMock.Verify(c => c.QueueBind(QueueName, ExchangeName, It.IsAny<string>(), null), Times.Exactly(3));
     }
     

--- a/Wrappit/Configuration/IWrappitContext.cs
+++ b/Wrappit/Configuration/IWrappitContext.cs
@@ -7,6 +7,8 @@ public interface IWrappitContext : IDisposable
     public IConnection Connection { get; }
     public string ExchangeName { get; }
     public string QueueName { get; }
+    public string QueueType { get; }
+    public int DeliveryLimit { get; }
 
     public IModel CreateChannel();
 }

--- a/Wrappit/Configuration/IWrappitContext.cs
+++ b/Wrappit/Configuration/IWrappitContext.cs
@@ -7,7 +7,6 @@ public interface IWrappitContext : IDisposable
     public IConnection Connection { get; }
     public string ExchangeName { get; }
     public string QueueName { get; }
-    public string QueueType { get; }
     public int DeliveryLimit { get; }
 
     public IModel CreateChannel();

--- a/Wrappit/Configuration/IWrappitOptions.cs
+++ b/Wrappit/Configuration/IWrappitOptions.cs
@@ -11,6 +11,8 @@ public interface IWrappitOptions
  
     public string ExchangeName { get; set; }
     public string QueueName { get; set; }
+    public string QueueType { get; set; }
+    public int DeliveryLimit { get; set; }
 
     public IConnectionFactory CreateFactory();
 }

--- a/Wrappit/Configuration/IWrappitOptions.cs
+++ b/Wrappit/Configuration/IWrappitOptions.cs
@@ -11,7 +11,6 @@ public interface IWrappitOptions
  
     public string ExchangeName { get; set; }
     public string QueueName { get; set; }
-    public string QueueType { get; set; }
     public int DeliveryLimit { get; set; }
 
     public IConnectionFactory CreateFactory();

--- a/Wrappit/Configuration/WrappitContext.cs
+++ b/Wrappit/Configuration/WrappitContext.cs
@@ -37,7 +37,6 @@ internal class WrappitContext : IWrappitContext
 
     public string ExchangeName => _options.ExchangeName;
     public string QueueName => _options.QueueName;
-    public string QueueType => _options.QueueType;
     public int DeliveryLimit => _options.DeliveryLimit;
 
     public WrappitContext(IWrappitOptions options, ILogger<WrappitContext> logger)

--- a/Wrappit/Configuration/WrappitContext.cs
+++ b/Wrappit/Configuration/WrappitContext.cs
@@ -37,6 +37,8 @@ internal class WrappitContext : IWrappitContext
 
     public string ExchangeName => _options.ExchangeName;
     public string QueueName => _options.QueueName;
+    public string QueueType => _options.QueueType;
+    public int DeliveryLimit => _options.DeliveryLimit;
 
     public WrappitContext(IWrappitOptions options, ILogger<WrappitContext> logger)
     {

--- a/Wrappit/Configuration/WrappitOptions.cs
+++ b/Wrappit/Configuration/WrappitOptions.cs
@@ -10,7 +10,6 @@ public class WrappitOptions : IWrappitOptions
     public string Password { get; set; } = "guest";
     public string ExchangeName { get; set; } = "Wrappit.DefaultExchangeName";
     public string QueueName { get; set; } = "Wrappit.DefaultQueueName";
-    public string QueueType { get; set; } = "quorum";
     public int DeliveryLimit { get; set; } = 10;
 
     public IConnectionFactory CreateFactory()

--- a/Wrappit/Configuration/WrappitOptions.cs
+++ b/Wrappit/Configuration/WrappitOptions.cs
@@ -10,7 +10,9 @@ public class WrappitOptions : IWrappitOptions
     public string Password { get; set; } = "guest";
     public string ExchangeName { get; set; } = "Wrappit.DefaultExchangeName";
     public string QueueName { get; set; } = "Wrappit.DefaultQueueName";
-    
+    public string QueueType { get; set; } = "quorum";
+    public int DeliveryLimit { get; set; } = 10;
+
     public IConnectionFactory CreateFactory()
     {
         return new ConnectionFactory

--- a/Wrappit/Extensions/ServiceCollectionExtensions.cs
+++ b/Wrappit/Extensions/ServiceCollectionExtensions.cs
@@ -15,6 +15,7 @@ public static class ServiceCollectionExtensions
     private const string EnvPassword = "Wrappit_Password";
     private const string EnvExchangeName = "Wrappit_ExchangeName";
     private const string EnvQueueName = "Wrappit_QueueName";
+    private const string EnvDeliveryLimit = "Wrappit_DeliveryLimit";
     
     public static IServiceCollection AddWrappit(this IServiceCollection collection)
     {
@@ -28,6 +29,13 @@ public static class ServiceCollectionExtensions
             QueueName = Environment.GetEnvironmentVariable(EnvQueueName) ?? throw MissingEnvVariable(EnvQueueName),
         };
 
+        var deliveryLimit = Environment.GetEnvironmentVariable(EnvDeliveryLimit);
+        if (deliveryLimit == null)
+        {
+            return AddWrappit(collection, options);
+        }
+        
+        options.DeliveryLimit = int.Parse(deliveryLimit);
         return AddWrappit(collection, options);
     }
     

--- a/Wrappit/Messaging/BasicReciever.cs
+++ b/Wrappit/Messaging/BasicReciever.cs
@@ -23,15 +23,8 @@ internal class BasicReciever : IBasicReciever
     {
         _context = context;
         _logger = logger;
-
-        if (_context.QueueType != DefaultQueueType)
-        {
-            return;
-        }
-        
-        _queueArguments["x-queue-type"] = _context.QueueType;
+        _queueArguments["x-queue-type"] = DefaultQueueType;
         _queueArguments["x-delivery-limit"] = _context.DeliveryLimit;
-
     }
 
     public void SetUpQueue(IEnumerable<string> topics)

--- a/Wrappit/Messaging/BasicReciever.cs
+++ b/Wrappit/Messaging/BasicReciever.cs
@@ -9,8 +9,11 @@ namespace Wrappit.Messaging;
 
 internal class BasicReciever : IBasicReciever
 {
+    private const string DefaultQueueType = "quorum";
+    
     private readonly IWrappitContext _context;
     private readonly ILogger<IBasicReciever> _logger;
+    private readonly IDictionary<string, object> _queueArguments = new Dictionary<string, object>();
 
     private IModel? _channel;
     private bool _queueDeclared;
@@ -20,6 +23,15 @@ internal class BasicReciever : IBasicReciever
     {
         _context = context;
         _logger = logger;
+
+        if (_context.QueueType != DefaultQueueType)
+        {
+            return;
+        }
+        
+        _queueArguments["x-queue-type"] = _context.QueueType;
+        _queueArguments["x-delivery-limit"] = _context.DeliveryLimit;
+
     }
 
     public void SetUpQueue(IEnumerable<string> topics)
@@ -27,7 +39,7 @@ internal class BasicReciever : IBasicReciever
         var topicsList = CanSetUpQueue(topics);
 
         using var channel = _context.CreateChannel();
-        channel.QueueDeclare(_context.QueueName, true, false, false, null);
+        channel.QueueDeclare(_context.QueueName, true, false, false, _queueArguments);
         _logger.LogDebug("Queue with name {name} set up.", _context.QueueName);
         
         foreach (var topic in topicsList)

--- a/Wrappit/Wrappit.csproj
+++ b/Wrappit/Wrappit.csproj
@@ -4,7 +4,7 @@
         <TargetFramework>net6.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <Version>1.0.1</Version>
+        <Version>1.1.0</Version>
         <Authors>Xander Vedder</Authors>
         <Product>Wrappit</Product>
         <Description>A simple wrapper around RabbitMQ.</Description>


### PR DESCRIPTION
Changes the queue type to `quorum`, which is able to 'poison' messages. With this change, rabbitmq can keep track of which messages have been ACKed and NACKed repeatedly after eachother. If this ACK/NACK combo reaches the given threshold, the message is sent to a deadletter queue (if configured).

We can configure this in Wrappit with the new option `DeliveryLimit`

fixes #1 