### PR TITLE
Add DurableExchange option

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ builder.Services.AddWrappit(new WrappitOptions
     // Optionally add the following:
     DeliveryLimit = 5,
     DurableQueue = false,
+    DurableExchange = false,
     AutoDeleteQueue = true,
 });
 
@@ -41,6 +42,7 @@ These options can be ommitted if the following environment variables have been s
    * `Wrappit_DeliveryLimit`.
         The default is `10`. This delivery limit is used when a handle method fails, this prevents infinite requeuing (see the related [issue](https://github.com/xandervedder/Wrappit/issues/1)).
    * `Wrappit_DurableQueue`.
+   * `Wrappit_DurableExchange`.
    * `Wrappit_AutoDeleteQueue`.
 
 

--- a/Wrappit/Wrappit.Test/Configuration/WrappitContextTest.cs
+++ b/Wrappit/Wrappit.Test/Configuration/WrappitContextTest.cs
@@ -34,6 +34,7 @@ public class WrappitContextTest
         Assert.AreEqual("Wrappit.DefaultExchangeName", context.ExchangeName);
         Assert.AreEqual("Wrappit.DefaultQueueName", context.QueueName);
         Assert.AreEqual(true, context.DurableQueue);
+        Assert.AreEqual(true, context.DurableExchange);
         Assert.AreEqual(false, context.AutoDeleteQueue);
     }
 
@@ -59,6 +60,7 @@ public class WrappitContextTest
         // Arrange
         const string exchangeName = "Wrappit.Exchange";
         _optionsMock.Setup(o => o.ExchangeName).Returns(exchangeName);
+        _optionsMock.Setup(o => o.DurableExchange).Returns(true);
 
         var wrappitContext = new WrappitContext(_optionsMock.Object, new NullLogger<WrappitContext>());
 

--- a/Wrappit/Wrappit.Test/Configuration/WrappitOptionsTest.cs
+++ b/Wrappit/Wrappit.Test/Configuration/WrappitOptionsTest.cs
@@ -39,7 +39,7 @@ public class WrappitOptionsTest
             QueueName = "Wrappit.Queue",
             DeliveryLimit = 1,
             DurableQueue = false,
-            DurableExchange = true,
+            DurableExchange = false,
             AutoDeleteQueue = true,
         };
 
@@ -52,7 +52,7 @@ public class WrappitOptionsTest
         Assert.AreEqual("Wrappit.Queue", options.QueueName);
         Assert.AreEqual(1, options.DeliveryLimit);
         Assert.AreEqual(false, options.DurableQueue);
-        Assert.AreEqual(true, options.DurableExchange);
+        Assert.AreEqual(false, options.DurableExchange);
         Assert.AreEqual(true, options.AutoDeleteQueue);
     }
 

--- a/Wrappit/Wrappit.Test/Configuration/WrappitOptionsTest.cs
+++ b/Wrappit/Wrappit.Test/Configuration/WrappitOptionsTest.cs
@@ -21,6 +21,7 @@ public class WrappitOptionsTest
         Assert.AreEqual("Wrappit.DefaultQueueName", options.QueueName);
         Assert.AreEqual(10, options.DeliveryLimit);
         Assert.AreEqual(true, options.DurableQueue);
+        Assert.AreEqual(true, options.DurableExchange);
         Assert.AreEqual(false, options.AutoDeleteQueue);
     }
 
@@ -38,6 +39,7 @@ public class WrappitOptionsTest
             QueueName = "Wrappit.Queue",
             DeliveryLimit = 1,
             DurableQueue = false,
+            DurableExchange = true,
             AutoDeleteQueue = true,
         };
 
@@ -50,6 +52,7 @@ public class WrappitOptionsTest
         Assert.AreEqual("Wrappit.Queue", options.QueueName);
         Assert.AreEqual(1, options.DeliveryLimit);
         Assert.AreEqual(false, options.DurableQueue);
+        Assert.AreEqual(true, options.DurableExchange);
         Assert.AreEqual(true, options.AutoDeleteQueue);
     }
 

--- a/Wrappit/Wrappit/Configuration/IWrappitContext.cs
+++ b/Wrappit/Wrappit/Configuration/IWrappitContext.cs
@@ -7,6 +7,7 @@ public interface IWrappitContext : IDisposable
     public IConnection Connection { get; }
     
     public string ExchangeName { get; }
+    public bool DurableExchange {get; }
     public string QueueName { get; }
     public int DeliveryLimit { get; }
     public bool DurableQueue { get; }

--- a/Wrappit/Wrappit/Configuration/IWrappitOptions.cs
+++ b/Wrappit/Wrappit/Configuration/IWrappitOptions.cs
@@ -10,6 +10,7 @@ public interface IWrappitOptions
     public string Password { get; set; }
  
     public string ExchangeName { get; set; }
+    public bool DurableExchange {get; set; }
     public string QueueName { get; set; }
     public int DeliveryLimit { get; set; }
     public bool DurableQueue { get; set; }

--- a/Wrappit/Wrappit/Configuration/WrappitContext.cs
+++ b/Wrappit/Wrappit/Configuration/WrappitContext.cs
@@ -24,7 +24,7 @@ internal class WrappitContext : IWrappitContext
                     {
                         _connection = _options.CreateFactory().CreateConnection();
                         using var channel = _connection.CreateModel();
-                        channel.ExchangeDeclare(_options.ExchangeName, ExchangeType.Topic, true, false, null);
+                        channel.ExchangeDeclare(_options.ExchangeName, ExchangeType.Topic, _options.DurableExchange, false, null);
                         
                         _logger.LogDebug("Created exchange with name {exchangeName}.", _options.ExchangeName);
                     }
@@ -36,6 +36,7 @@ internal class WrappitContext : IWrappitContext
     }
 
     public string ExchangeName => _options.ExchangeName;
+    public bool DurableExchange => _options.DurableExchange;
     public string QueueName => _options.QueueName;
     public int DeliveryLimit => _options.DeliveryLimit;
     public bool DurableQueue => _options.DurableQueue;

--- a/Wrappit/Wrappit/Configuration/WrappitOptions.cs
+++ b/Wrappit/Wrappit/Configuration/WrappitOptions.cs
@@ -9,6 +9,7 @@ public class WrappitOptions : IWrappitOptions
     public string UserName { get; set; } = "guest";
     public string Password { get; set; } = "guest";
     public string ExchangeName { get; set; } = "Wrappit.DefaultExchangeName";
+    public bool DurableExchange {get; set; } = true;
     public string QueueName { get; set; } = "Wrappit.DefaultQueueName";
     public int DeliveryLimit { get; set; } = 10;
     public bool DurableQueue { get; set; } = true;

--- a/Wrappit/Wrappit/Extensions/ServiceCollectionExtensions.cs
+++ b/Wrappit/Wrappit/Extensions/ServiceCollectionExtensions.cs
@@ -24,6 +24,7 @@ public static class ServiceCollectionExtensions
     
     private const string EnvDeliveryLimit = "Wrappit_DeliveryLimit";
     private const string EnvDurableQueue = "Wrappit_DurableQueue";
+    private const string EnvDurableExchange = "Wrappit_DurableExchange";
     private const string EnvAutoDeleteQueue = "Wrappit_AutoDeleteQueue";
     
     #endregion
@@ -57,6 +58,12 @@ public static class ServiceCollectionExtensions
         if (durableQueue != null)
         {
             options.DurableQueue = bool.Parse(durableQueue);
+        }
+
+        var durableExchange = Environment.GetEnvironmentVariable(EnvDurableExchange);
+        if (durableExchange != null)
+        {
+            options.DurableExchange = bool.Parse(durableExchange);
         }
 
         var autoDeleteQueue = Environment.GetEnvironmentVariable(EnvAutoDeleteQueue);

--- a/Wrappit/Wrappit/Wrappit.csproj
+++ b/Wrappit/Wrappit/Wrappit.csproj
@@ -4,7 +4,7 @@
         <TargetFrameworks>net7.0;net6.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <Version>1.1.7</Version>
+        <Version>1.1.8</Version>
         <Authors>Xander Vedder</Authors>
         <Product>Wrappit</Product>
         <Description>A simple wrapper around RabbitMQ.</Description>


### PR DESCRIPTION
This fork will add the DurableExchange to Wrappit and increases the package version to 1.1.8
The environment variable `Wrappit_DurableExchange` can be used to configure it if the Options object is not used. The default value for DurableExchange is `true`